### PR TITLE
Messagearea support priority field and sort for New Folder

### DIFF
--- a/backend/messagearea/models.py
+++ b/backend/messagearea/models.py
@@ -49,7 +49,7 @@ class Conversation(models.Model):
         return self._latest
 
     @property
-    def priority(self):
+    def is_priority(self):
         # this is for testing the priority flag
         if self.sender_email == "someguy@mailinator.com":
             return True
@@ -71,7 +71,7 @@ class Conversation(models.Model):
             "has_attachments": False,
             "rating": self.rating,
 
-            "priority": self.priority,
+            "priority": self.is_priority,
 
             "notes": self.notes,
             "is_read": self.is_read or False,

--- a/backend/messagearea/models.py
+++ b/backend/messagearea/models.py
@@ -48,6 +48,13 @@ class Conversation(models.Model):
     def latest_message(self):
         return self._latest
 
+    @property
+    def priority(self):
+        # this is for testing the priority flag
+        if self.sender_email == "someguy@mailinator.com":
+            return True
+        return False
+
     def to_json(self, include_messages=False):
         data = {
             "id": self.id,
@@ -63,6 +70,8 @@ class Conversation(models.Model):
 
             "has_attachments": False,
             "rating": self.rating,
+
+            "priority": self.priority,
 
             "notes": self.notes,
             "is_read": self.is_read or False,

--- a/src/ConversationData.res
+++ b/src/ConversationData.res
@@ -35,6 +35,7 @@ type rec conversation = {
   zipcode: option<string>,
   city: option<string>,
   source: string,
+  priority: bool,
   date_last_message: string,
   count_messages: int,
   latest_message: message,

--- a/src/ConversationListItem.res
+++ b/src/ConversationListItem.res
@@ -68,9 +68,9 @@ let make = (
     </div>
     <div className="flex flex-row">
       <div className="inline-block mt-1 text-xs">
-        <IsoDate date={Js.Date.fromString(conversation.date_last_message)} />
+        <IsoDate date={Js.Date.fromString(replaceSpaceWithT(conversation.date_last_message))} />
         {" um "->React.string}
-        <IsoTime date={Js.Date.fromString(conversation.date_last_message)} />
+        <IsoTime date={Js.Date.fromString(replaceSpaceWithT(conversation.date_last_message))} />
       </div>
     </div>
     <div>

--- a/src/MessageItem.res
+++ b/src/MessageItem.res
@@ -4,7 +4,7 @@ open Utils
 @react.component
 let make = (~message: message) => {
   <div
-    className={"border-2 rounded bg-slate-50 px-4 py-4 " ++
+    className={"border-2 rounded bg-white px-4 py-4 " ++
     switch message.type_ {
     | Incoming => "lg:mr-20"
     | Outgoing => "lg:ml-20"

--- a/src/MessageItem.res
+++ b/src/MessageItem.res
@@ -1,4 +1,5 @@
 open ConversationData
+open Utils
 
 @react.component
 let make = (~message: message) => {
@@ -17,9 +18,9 @@ let make = (~message: message) => {
           {"Beantwortet am "->React.string}
         </span>
       }}
-      <IsoDate date={Js.Date.fromString(message.date)} />
+      <IsoDate date={Js.Date.fromString(replaceSpaceWithT(message.date))} />
       {" um "->React.string}
-      <IsoTime date={Js.Date.fromString(message.date)} />
+      <IsoTime date={Js.Date.fromString(replaceSpaceWithT(message.date))} />
     </span>
     <hr className="mb-2" />
     <p className="whitespace-pre-line"> {message.content->React.string} </p>

--- a/src/Utils.res
+++ b/src/Utils.res
@@ -23,3 +23,7 @@ let getScrollTop: Dom.element => int = %raw(`
        return domNode.scrollTop;
      }
   `)
+
+let replaceSpaceWithT = (str: string): string => {
+  Js.String.replace(" ", "T", str)
+}

--- a/src/app.res
+++ b/src/app.res
@@ -34,11 +34,19 @@ let filterConversations = (
       !c.is_in_trash || interactedWithConversations->List.has(c.id, (a, b) => a == b)
     )
   | New =>
-    conversations->Js.Array2.filter((c: conversation) =>
-      (!c.is_in_trash && (c.rating == Unrated && (!c.is_replied_to && !c.is_ignored))) ||
+    conversations
+      ->Js.Array2.filter((c: conversation) =>
+        (!c.is_in_trash && (c.rating == Unrated && (!c.is_replied_to && !c.is_ignored))) ||
         ((!c.is_in_trash && !c.is_read) ||
         interactedWithConversations->List.has(c.id, (a, b) => a == b))
-    )
+      )
+      ->Array.sort((a, b) =>
+        switch (a.priority, b.priority) {
+          | (true, false) => -1
+          | (false, true) => 1
+          | _ => 0
+        }
+      )
   | ByRating(rating) =>
     conversations->Js.Array2.filter(c =>
       (!c.is_in_trash && c.rating == rating) ||


### PR DESCRIPTION
- [x] I have performed a code review of my own work before submitting

### What is new?

(Sorry forgot to push)
- Fix for Safari time bug
- Messages background color now white

(priority related stuff)
- Messagearea support priority field
- Added priority field to backend with 1 test email.
- Conversations sorted for `New Folder` so `priority == true` is on top

### Screenshot
Anonymous would be last but thanks to `priority` he on top.
<img width="911" alt="Screenshot 2023-06-20 at 16 47 06" src="https://github.com/hendi/anfragenverwaltung/assets/86942951/5fd31066-404e-46b8-bb9f-afd95815e6df">

